### PR TITLE
UEGitPlugin에 대한 ini 세팅 추가

### DIFF
--- a/Config/DefaultEditorPerProjectUserSettings.ini
+++ b/Config/DefaultEditorPerProjectUserSettings.ini
@@ -1,3 +1,12 @@
 [ContentBrowser]
 ContentBrowserTab1.SelectedPaths=/Game/FirstPerson
 
+[/Script/UnrealEd.EditorLoadingSavingSettings]
+bSCCAutoAddNewFiles=False
+[/Script/UnrealEd.EditorLoadingSavingSettings]
+bAutomaticallyCheckoutOnAssetModification=False
+bPromptForCheckoutOnAssetModification=True
+[/Script/UnrealEd.EditorPerProjectUserSettings]
+bAutoloadCheckedOutPackages=True
+[SystemSettingsEditor]
+r.Editor.SkipSourceControlCheckForEditablePackages=1

--- a/Config/DefaultEditorPerProjectUserSettings.ini
+++ b/Config/DefaultEditorPerProjectUserSettings.ini
@@ -3,7 +3,6 @@ ContentBrowserTab1.SelectedPaths=/Game/FirstPerson
 
 [/Script/UnrealEd.EditorLoadingSavingSettings]
 bSCCAutoAddNewFiles=False
-[/Script/UnrealEd.EditorLoadingSavingSettings]
 bAutomaticallyCheckoutOnAssetModification=False
 bPromptForCheckoutOnAssetModification=True
 [/Script/UnrealEd.EditorPerProjectUserSettings]


### PR DESCRIPTION
# 설명
로컬 UEGitPlugin을 사용하도록 설정하고 사용시의 기본 세팅 ini를 추가했습니다
# 사유
git lfs가 바이너리 에셋의 수정에 대한 탐지가 거짓 양성이 되는 문제를 완화하기 위함입니다. 

git lfs는 에셋을 해쉬 값을 통해서 관리하기 때문에 설령 되돌리기를 통해 언리얼의 바이너리 에셋이 이전과 동일하거나, 단순히 저장을 할 때도 다른 해쉬 값을 가져 에셋이 수정되었다고 인식합니다. 

UEGitPlugin를 도입하고 명시적인 락을 걸도록 설정하면 위 문제를 완벽하게 해결하지는 못하지만, 의도치 않은 에셋의 해쉬 값 수정을 조금이나마 방지할 수 있습니다.
