### PR TITLE
fix: 로딩스크린에서 머터리얼이 출력되지 않는 문제 해결 (Closes: #4)

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -28,6 +28,7 @@ TransitionMap=/Game/Maps/TransitionMap.TransitionMap
 GameInstanceClass=/Game/Gunner/_Core/BP_GunnerGameInstance.BP_GunnerGameInstance_C
 GameDefaultMap=/Game/Maps/MainMenu.MainMenu
 GlobalDefaultGameMode=/Game/Gunner/_Core/BP_GunnerGameMode.BP_GunnerGameMode_C
+EditorStartupMap=/Game/Maps/FirstPersonMap.FirstPersonMap
 
 [/Script/Engine.RendererSettings]
 r.Mobile.ShadingPath=0

--- a/Content/Gunner/UI/OutOfGame/LoadingScreen/BP_LoadingScreenActor.uasset
+++ b/Content/Gunner/UI/OutOfGame/LoadingScreen/BP_LoadingScreenActor.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b58b9aba8d18301b78491e6da23577034de4b33c52e91ad69da73539b7fdeb4
+size 24626

--- a/Content/Gunner/UI/OutOfGame/LoadingScreen/WBP_LoadingGame.uasset
+++ b/Content/Gunner/UI/OutOfGame/LoadingScreen/WBP_LoadingGame.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad5f67d99223f0462e1785d65cd2ae8f787dd65b63992b9e2f78a0c645f621f0
-size 168939
+oid sha256:0075ca0a73d48623fa0ec28ab81730afa8143ddc378b50e44121b7e8414ba22e
+size 171072

--- a/Content/Gunner/UI/OutOfGame/LoadingScreen/WBP_LoadingGame_NEW.uasset
+++ b/Content/Gunner/UI/OutOfGame/LoadingScreen/WBP_LoadingGame_NEW.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:286bfce2435e360ab838641bdb2cbf8091a5b4d05089a9d98da3d88c1f9b2397
-size 356785

--- a/Content/Gunner/UI/OutOfGame/Lobby/WBP_Lobby.uasset
+++ b/Content/Gunner/UI/OutOfGame/Lobby/WBP_Lobby.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9dfe37cf5c58f0973755b1ef7a0bd6b319ba3890a70c5790c0bbe90acd076ead
-size 345846
+oid sha256:9bfd4669543389d53e626ecc4e1b595d6dad50eaf22504a9aea779683cf9ad1a
+size 345536

--- a/Content/Gunner/_Core/BP_GunnerGameInstance.uasset
+++ b/Content/Gunner/_Core/BP_GunnerGameInstance.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df01e1c61ec9b68503b6790343c32e7b85181baddb7895b226f0678b1521143d
+oid sha256:f31df66e46ce5e503e22e55a75cff5233182a0141f16e67584c38fe36c03ec6f
 size 6445

--- a/Content/Maps/MainMenu.umap
+++ b/Content/Maps/MainMenu.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b86baa60efdfd603bafb536179f3c32718ce889b17ce58e61dfd44d77028201b
-size 11087
+oid sha256:501e262620277febf104a1414337999dcee75b4d78150739b27ec209e1c6a965
+size 13635

--- a/Source/Gunner/Gunner.Build.cs
+++ b/Source/Gunner/Gunner.Build.cs
@@ -10,7 +10,7 @@ public class Gunner : ModuleRules
 		
 		if(Target.bBuildEditor)
 		{
-			PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG", "Slate", "SlateCore", "GameplayTags", "OnlineSubsystem", "OnlineSubsystemSteam", "OnlineSubsystemNull","Niagara", "AIModule", "NexusAction", "RenderCore", "Json" });
+			PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG", "Slate", "SlateCore", "GameplayTags", "OnlineSubsystem", "OnlineSubsystemSteam", "OnlineSubsystemNull","Niagara", "AIModule", "NexusAction", "RenderCore", "Json", "RHI" });
 		}
 		else
 		{

--- a/Source/Gunner/Gunner.Build.cs
+++ b/Source/Gunner/Gunner.Build.cs
@@ -10,7 +10,7 @@ public class Gunner : ModuleRules
 		
 		if(Target.bBuildEditor)
 		{
-			PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG", "Slate", "SlateCore", "GameplayTags", "OnlineSubsystem", "OnlineSubsystemSteam", "OnlineSubsystemNull","Niagara", "AIModule", "NexusAction", "RenderCore", "Json", "RHI" });
+			PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG", "Slate", "SlateCore", "GameplayTags", "OnlineSubsystem", "OnlineSubsystemSteam", "OnlineSubsystemNull","Niagara", "AIModule", "NexusAction", "RenderCore", "Json" });
 		}
 		else
 		{

--- a/Source/Gunner/_Core/GunnerGameInstance.cpp
+++ b/Source/Gunner/_Core/GunnerGameInstance.cpp
@@ -5,18 +5,15 @@
 
 #include "MoviePlayer.h"
 #include "Blueprint/UserWidget.h"
+#include "Components/Image.h"
 #include "Prediction/NexusPrediction.h"
+
 
 void UGunnerGameInstance::Init()
 {
 	Super::Init();
-
-	FCoreUObjectDelegates::PostLoadMapWithWorld.RemoveAll(this);
-	FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(this, &UGunnerGameInstance::PostLoadMapWithWorld);
-	
 	FWorldDelegates::OnSeamlessTravelStart.RemoveAll(this);
 	FWorldDelegates::OnSeamlessTravelStart.AddUObject(this, &UGunnerGameInstance::OnSeamlessTravelStart);
-	
 }
 
 void UGunnerGameInstance::Shutdown()
@@ -30,29 +27,18 @@ void UGunnerGameInstance::OnSeamlessTravelStart(UWorld* World, const FString& Ma
 	PlayLoadingScreen();
 }
 
-void UGunnerGameInstance::PostLoadMapWithWorld(UWorld* InLoadedWorld)
-{
-	StopLoadingScreen();
-}
-
-
 void UGunnerGameInstance::PlayLoadingScreen()
 {
 	if (LoadingScreenWidgetClass)
 	{
+		UUserWidget* LoadingScreenWidget = CreateWidget<UUserWidget>(this, LoadingScreenWidgetClass);
 		FLoadingScreenAttributes LoadingScreenAttributes;
-		LoadingScreenWidget = CreateWidget<UUserWidget>(this, LoadingScreenWidgetClass);
 		LoadingScreenAttributes.WidgetLoadingScreen = LoadingScreenWidget->TakeWidget();
 		LoadingScreenAttributes.MinimumLoadingScreenDisplayTime = 5.0f;
-		LoadingScreenAttributes.bAutoCompleteWhenLoadingCompletes = false;
+		LoadingScreenAttributes.bAutoCompleteWhenLoadingCompletes = true;
 		LoadingScreenAttributes.bAllowEngineTick = true;
 
 		GetMoviePlayer()->SetupLoadingScreen(LoadingScreenAttributes);
 		GetMoviePlayer()->PlayMovie();
 	}
-}
-
-void UGunnerGameInstance::StopLoadingScreen()
-{
-	//GetMoviePlayer()->StopMovie();
 }

--- a/Source/Gunner/_Core/GunnerGameInstance.h
+++ b/Source/Gunner/_Core/GunnerGameInstance.h
@@ -22,10 +22,7 @@ public:
 
 private:
 	void OnSeamlessTravelStart(UWorld* World, const FString& MapName);
-	void OnPreLoadMap(const FString& String);
-	void PostLoadMapWithWorld(UWorld* InLoadedWorld);
 	void PlayLoadingScreen();
-	void StopLoadingScreen();
 
 public:
 	UPROPERTY(EditAnywhere)
@@ -34,6 +31,4 @@ public:
 protected:
 	UPROPERTY(EditAnywhere)
 	TSubclassOf<UUserWidget> LoadingScreenWidgetClass;
-	UPROPERTY()
-	TObjectPtr<UUserWidget> LoadingScreenWidget;
 };


### PR DESCRIPTION
# 원인
로딩스크린이 `MoviePlayer`에 의해 보여질 시 머터리얼의 셰이더가 아직 준비되지 않았던 것이 원인이었습니다

# 해결 

https://github.com/user-attachments/assets/63ee8557-adeb-452e-a7bd-1cfc76095e13

*정상적으로 모든 머터리얼이 출력되는 영상*

`MainMenu`레벨에 로딩스크린을 `WidgetComponent`로 가지는 `Actor`를 배치하여 강제적으로 게임시작시 머터리얼의 셰이더가 준비되도록 하였습니다